### PR TITLE
Fixed issue on days left being off by one day

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -81,7 +81,7 @@
           let todays_date = new Date()
           let due_date = Date.parse(bill['due_date'])
 
-          var days_left = Math.round(
+          var days_left = Math.ceil(
             Math.abs((due_date - todays_date) / oneDay)
           )
 


### PR DESCRIPTION
Was rounding down the calculated date rather than rounding up, which was resulting in all "days left" being off by one day. Now the frontend rounds UP and it produces the correct days left until bill is due.